### PR TITLE
Fixes converting an incomplete Key to its protobuf struct

### DIFF
--- a/lib/diplomat/key.ex
+++ b/lib/diplomat/key.ex
@@ -79,6 +79,9 @@ defmodule Diplomat.Key do
   end
 
   defp proto([], acc), do: acc
+  defp proto([[kind, id]|tail], acc) when is_nil(id) do
+    proto(tail, [PbPathElement.new(kind: kind, id_type: nil)|acc])
+  end
   defp proto([[kind, id]|tail], acc) when is_integer(id) do
     proto(tail, [PbPathElement.new(kind: kind, id_type: {:id, id})|acc])
   end

--- a/lib/diplomat/key.ex
+++ b/lib/diplomat/key.ex
@@ -106,6 +106,7 @@ defmodule Diplomat.Key do
       {:id, id} -> from_path_proto(tail, [[head.kind, id]|acc])
       # in case value return as char list
       {:name, name} -> from_path_proto(tail, [[head.kind, to_string(name)]|acc])
+      nil -> from_path_proto(tail, [[head.kind, nil]|acc])
     end
   end
 

--- a/test/diplomat/key_test.exs
+++ b/test/diplomat/key_test.exs
@@ -167,6 +167,11 @@ defmodule Diplomat.KeyTest do
     } |> Key.from_proto
   end
 
+  test "reads proto with an incomplete key" do
+    key = %Key{kind: "Test"}
+    assert key == key |> Key.proto |> Key.from_proto
+  end
+
   test "Key.incomplete?" do
     assert %Key{kind: "Asset"} |> Key.incomplete?
     refute %Key{id: 1}         |> Key.incomplete?

--- a/test/diplomat/key_test.exs
+++ b/test/diplomat/key_test.exs
@@ -117,6 +117,17 @@ defmodule Diplomat.KeyTest do
     assert <<_::binary>> = pb |> PbKey.encode
   end
 
+  test "converting an incomplete key to a protobuf" do
+    pb = Key.new("Book") |> Key.proto
+    assert %PbKey{
+      path: [
+        %PbKey.PathElement{kind: "Book", id_type: nil}
+      ]
+    } = pb
+
+    assert <<_::binary>> = pb |> PbKey.encode
+  end
+
   test "creating a key from a protobuf struct" do
     key = %Key{
       kind: "User",


### PR DESCRIPTION
I tried to insert an `Entity` with an incomplete `Key`, but was getting the following error:
```elixir
iex(26)> Diplomat.Entity.new(%{"name" => "foobar"}, "User") |> Diplomat.Entity.insert
** (ArgumentError) argument error
    (stdlib) :unicode.characters_to_binary(:undefined)
             src/gpb.erl:662: :gpb.encode_value/3
             src/gpb.erl:603: :gpb.encode_field_value/4
             src/gpb.erl:538: :gpb.encode_2/4
             src/gpb.erl:545: :gpb.encode_2/4
             src/gpb.erl:672: :gpb.encode_value/3
             src/gpb.erl:603: :gpb.encode_field_value/4
             src/gpb.erl:595: :gpb.encode_repeated/5
             src/gpb.erl:538: :gpb.encode_2/4
             src/gpb.erl:672: :gpb.encode_value/3
             src/gpb.erl:603: :gpb.encode_field_value/4
             src/gpb.erl:538: :gpb.encode_2/4
             src/gpb.erl:672: :gpb.encode_value/3
             src/gpb.erl:603: :gpb.encode_field_value/4
             src/gpb.erl:538: :gpb.encode_2/4
             src/gpb.erl:545: :gpb.encode_2/4
             src/gpb.erl:672: :gpb.encode_value/3
             src/gpb.erl:603: :gpb.encode_field_value/4
             src/gpb.erl:595: :gpb.encode_repeated/5
             src/gpb.erl:538: :gpb.encode_2/4
```

I narrowed the problem to `Key.proto`:
```elixir
iex(27)> Diplomat.Key.new("User") |> Diplomat.Key.proto
%Diplomat.Proto.Key{partition_id: nil,
 path: [%Diplomat.Proto.Key.PathElement{id_type: {:name, nil}, kind: "User"}]}
```

In order to receive an auto-generated key for our insert, our incomplete `Key` should have `{id_type: nil}`. With this patch, the following works as expected:
```elixir
iex(3)> Diplomat.Entity.new(%{"name" => "foobar"}, "User") |> Diplomat.Entity.insert
[%Diplomat.Key{id: 5732568548769792, kind: "User", name: nil, namespace: nil,
  parent: nil, project_id: "..."}]
```