### PR TITLE
Fixes Value.proto([])

### DIFF
--- a/lib/diplomat/value.ex
+++ b/lib/diplomat/value.ex
@@ -63,6 +63,8 @@ defmodule Diplomat.Value do
   end
   def proto(val) when is_bitstring(val),
     do: PbVal.new(value_type: {:blob_value, val})
+  def proto(val) when is_list(val),
+    do: proto_list(val, [])
   def proto(%DateTime{}=val) do
     timestamp = DateTime.to_unix(val, :nanoseconds)
     PbVal.new(
@@ -80,8 +82,6 @@ defmodule Diplomat.Value do
   # might need to be more explicit about this...
   def proto({latitude, longitude}) when is_float(latitude) and is_float(longitude),
     do: PbVal.new(value_type: {:geo_point_value, %PbLatLng{latitude: latitude, longitude: longitude}})
-  def proto([head|tail]),
-    do: proto_list([head|tail], [])
 
   defp proto_list([], acc) do
     PbVal.new(

--- a/test/diplomat/value_test.exs
+++ b/test/diplomat/value_test.exs
@@ -78,6 +78,12 @@ defmodule Diplomat.ValueTest do
     assert proto_values == [1, 2, 3]
   end
 
+  test "an empty list value" do
+    val = [] |> Value.proto
+    {:array_value, array} = val.value_type
+    assert array.values == []
+  end
+
   test "doesn't remove nil values from a list" do
     val = [1,nil,2] |> Value.proto
     {:array_value, array} = val.value_type


### PR DESCRIPTION
Was getting an error trying to serialize an empty array:
```elixir
** (exit) an exception was raised:
    ** (FunctionClauseError) no function clause matching in Diplomat.Value.proto/1
        lib/diplomat/value.ex:48: Diplomat.Value.proto([])
        lib/diplomat/entity.ex:60: anonymous fn/1 in Diplomat.Entity.proto/1
        (elixir) lib/enum.ex:1184: Enum."-map/2-lists^map/1-0-"/2
        lib/diplomat/entity.ex:59: Diplomat.Entity.proto/1
        lib/diplomat/value.ex:79: Diplomat.Value.proto/1
        lib/diplomat/entity.ex:60: anonymous fn/1 in Diplomat.Entity.proto/1
        (elixir) lib/enum.ex:1184: Enum."-map/2-lists^map/1-0-"/2
        (elixir) lib/enum.ex:1184: Enum."-map/2-lists^map/1-0-"/2
        lib/diplomat/entity.ex:59: Diplomat.Entity.proto/1
        lib/diplomat/entity.ex:171: Diplomat.Entity.extract_mutations/2
        lib/diplomat/entity.ex:157: Diplomat.Entity.commit_request/2
        lib/diplomat/entity.ex:125: Diplomat.Entity.insert/1
```