### PR TITLE
Fixes Entity.properties for arrays of Entities

### DIFF
--- a/lib/diplomat/entity.ex
+++ b/lib/diplomat/entity.ex
@@ -109,13 +109,18 @@ defmodule Diplomat.Entity do
   """
   def properties(%Entity{properties: properties}) do
     properties
-    |> Enum.map(fn {key, %Value{value: value}} ->
-      case value do
-        %Entity{} -> {key, value |> properties}
-        _ -> {key, value}
-      end
+    |> Enum.map(fn {key, value} ->
+      {key, value |> recurse_properties}
     end)
     |> Enum.into(%{})
+  end
+  defp recurse_properties(value) do
+    case value do
+      %Entity{} -> value |> properties
+      %Value{value: value} -> value |> recurse_properties
+      value when is_list(value) -> value |> Enum.map(&recurse_properties/1)
+      _ -> value
+    end
   end
 
   def insert(%Entity{}=entity), do: insert([entity])

--- a/test/diplomat/entity_test.exs
+++ b/test/diplomat/entity_test.exs
@@ -102,6 +102,14 @@ defmodule Diplomat.EntityTest do
     assert %{"person" => %{"firstName" => "Phil"}} == ent |> Entity.properties
   end
 
+  test "pulling properties of arrays of properties" do
+    properties = %{"person" => %{"firstName" => "Phil", "dogs" => [%{"name" => "Fido"}, %{"name" => "Woofer"}]}}
+    # cast to proto
+    ent = properties |> Entity.new("Person") |> Entity.proto |> Entity.from_proto
+    assert  properties == ent |> Entity.properties
+  end
+
+
   test "property names are converted to strings" do
     entity = Entity.new(%{:hello => "world"}, "CodeSnippet")
     assert %{"hello" => "world"} == Entity.properties(entity)


### PR DESCRIPTION
`Entity.properties` doesn't iterate through arrays of `Value`s of `Entity`, so arrays of hashes don't get processed properly.
```elixir
ex(8)> %{"person" => %{"firstName" => "Phil", "house" => %{address: "123 Main Street"}, "dogs" => [%{"name" => "Fido"}, %{"name" => "Woofer"}]}} |> Diplomat.Entity.new("Person", "key") |> Diplomat.Entity.proto |> Diplomat.Entity.from_proto
%Diplomat.Entity{key: %Diplomat.Key{id: nil, kind: "Person", name: "key",
  namespace: nil, parent: nil, project_id: nil}, kind: "Person",
 properties: %{"person" => %Diplomat.Value{value: %Diplomat.Entity{key: nil,
     kind: nil,
     properties: %{"dogs" => %Diplomat.Value{value: [%Diplomat.Value{value: %Diplomat.Entity{key: nil,
           kind: nil, properties: %{"name" => %Diplomat.Value{value: "Fido"}}}},
         %Diplomat.Value{value: %Diplomat.Entity{key: nil, kind: nil,
           properties: %{"name" => %Diplomat.Value{value: "Woofer"}}}}]},
       "firstName" => %Diplomat.Value{value: "Phil"},
       "house" => %Diplomat.Value{value: %Diplomat.Entity{key: nil, kind: nil,
         properties: %{"address" => %Diplomat.Value{value: "123 Main Street"}}}}}}}}}
iex(9)> %{"person" => %{"firstName" => "Phil", "house" => %{address: "123 Main Street"}, "dogs" => [%{"name" => "Fido"}, %{"name" => "Woofer"}]}} |> Diplomat.Entity.new("Person", "key") |> Diplomat.Entity.proto |> Diplomat.Entity.from_proto |> Diplomat.Entity.properties
%{"person" => %{"dogs" => [%Diplomat.Value{value: %Diplomat.Entity{key: nil,
       kind: nil, properties: %{"name" => %Diplomat.Value{value: "Fido"}}}},
     %Diplomat.Value{value: %Diplomat.Entity{key: nil, kind: nil,
       properties: %{"name" => %Diplomat.Value{value: "Woofer"}}}}],
    "firstName" => "Phil", "house" => %{"address" => "123 Main Street"}}}
```
