### PR TITLE
Dialyzer fixes

### DIFF
--- a/lib/diplomat/entity.ex
+++ b/lib/diplomat/entity.ex
@@ -6,11 +6,11 @@ defmodule Diplomat.Entity do
   @type t :: %__MODULE__{
     kind: String.t,
     key:  Diplomat.Key.t,
-    properties: %{String.t => Diplomat.Value.t}
+    properties: %{optional(String.t) => Diplomat.Value.t}
   }
   defstruct kind: nil, key: nil, properties: %{}
 
-  @spec new(%{}) :: t
+  @spec new(map()) :: t
   @doc """
   Creates a new `Diplomat.Entity` with the given properties.
 
@@ -18,12 +18,12 @@ defmodule Diplomat.Entity do
   should create your entities. `new` wraps and nests properties correctly, and
   ensures that your entities have a valid `Key` (among other things).
   """
-  def new(%{}=props),
+  def new(props) when is_map(props),
     do: %Entity{properties: value_properties(props)}
 
-  @spec new(%{}, Diplomat.Key.t) :: t
+  @spec new(map(), Diplomat.Key.t) :: t
   @doc "Creates a new `Diplomat.Entity` with the given properties and `Diplomat.Key`"
-  def new(%{}=props, %Key{kind: kind}=key) do
+  def new(props, %Key{kind: kind}=key) when is_map(props) do
     %Entity{
       kind: kind,
       key:  key,
@@ -31,7 +31,7 @@ defmodule Diplomat.Entity do
     }
   end
 
-  def new(%{}=props, kind \\ nil, id \\ nil) do
+  def new(props, kind \\ nil, id \\ nil) do
     %Entity{
       kind: kind,
       key: Key.new(kind, id),
@@ -39,7 +39,7 @@ defmodule Diplomat.Entity do
     }
   end
 
-  defp value_properties(%{} = props) do
+  defp value_properties(props) when is_map(props) do
     props
     |> Map.to_list
     |> Enum.map(fn {name, value} -> {to_string(name), Value.new(value)} end)

--- a/lib/diplomat/key.ex
+++ b/lib/diplomat/key.ex
@@ -14,29 +14,31 @@ defmodule Diplomat.Key do
   auto-assign an id by calling the API to allocate an id for the `Key`.
   """
   @type t :: %__MODULE__{
-    id:         String.t,
-    name:       String.t,
+    id:         String.t | nil,
+    name:       String.t | nil,
     kind:       String.t,
-    parent:     Diplomat.Entity.t,
-    project_id: String.t,
-    namespace:  String.t
+    parent:     Diplomat.Key.t | nil,
+    project_id: String.t | nil,
+    namespace:  String.t | nil
   }
 
   defstruct [:id, :name, :kind, :parent, :project_id, :namespace]
 
   @spec new(String.t) :: t
-  @spec new(String.t, String.t) :: t
-  @spec new(String.t, String.t, t) :: t
   @doc "Creates a new `Diplomat.Key` from a kind"
   def new(kind),
     do: %__MODULE__{kind: kind}
+
+  @spec new(String.t, String.t) :: t
   @doc "Creates a new `Diplomat.Key` from a kind and id"
   def new(kind, id) when is_integer(id),
     do: %__MODULE__{kind: kind, id: id}
   @doc "Creates a new `Diplomat.Key` form a kind and a name"
   def new(kind, name),
     do: %__MODULE__{kind: kind, name: name}
-  @doc "Creates a new `Diplomat.Key` from a king, an id or name, and a parent Entity"
+
+  @spec new(String.t, String.t, t) :: t
+  @doc "Creates a new `Diplomat.Key` from a kind, an id or name, and a parent Entity"
   def new(kind, id_or_name, %__MODULE__{}=parent),
     do: %{new(kind, id_or_name) | parent: parent}
 


### PR DESCRIPTION
* `Diplomat.Key.parent` field was using the wrong type (`Diplomat.Entity.t` instead of `Diplomat.Key.t`)
* Several fields on `Diplomat.Key` are optional and need type specs that allow for `nil`.
* Some type specs were using `%{}` to represent a map type, but this literally means an empty map so they were replaced with the type `map()`.
* Replaced a few instances of pattern matching on `%{}` with `when is_map(...)`.