### PR TITLE
Treat structs as maps when serializing Entities

### DIFF
--- a/lib/diplomat/entity.ex
+++ b/lib/diplomat/entity.ex
@@ -18,11 +18,13 @@ defmodule Diplomat.Entity do
   should create your entities. `new` wraps and nests properties correctly, and
   ensures that your entities have a valid `Key` (among other things).
   """
+  def new(props = %{__struct__: _struct}), do: Map.from_struct(props) |> new()
   def new(props) when is_map(props),
     do: %Entity{properties: value_properties(props)}
 
   @spec new(map(), Diplomat.Key.t) :: t
   @doc "Creates a new `Diplomat.Entity` with the given properties and `Diplomat.Key`"
+  def new(props = %{__struct__: _struct}, key), do: new(Map.from_struct(props), key)
   def new(props, %Key{kind: kind}=key) when is_map(props) do
     %Entity{
       kind: kind,
@@ -39,6 +41,11 @@ defmodule Diplomat.Entity do
     }
   end
 
+  defp value_properties(props = %{__struct__: _struct}) do
+    props
+    |> Map.from_struct()
+    |> value_properties()
+  end
   defp value_properties(props) when is_map(props) do
     props
     |> Map.to_list

--- a/lib/diplomat/value.ex
+++ b/lib/diplomat/value.ex
@@ -58,6 +58,8 @@ defmodule Diplomat.Value do
     do: PbVal.new(value_type: {:integer_value, val})
   def proto(val) when is_float(val),
     do: PbVal.new(value_type: {:double_value, val})
+  def proto(val) when is_atom(val),
+    do: val |> to_string() |> proto()
   def proto(val) when is_binary(val) do
     case String.valid?(val) do
       true -> PbVal.new(value_type: {:string_value, val})

--- a/test/diplomat/value_test.exs
+++ b/test/diplomat/value_test.exs
@@ -105,6 +105,12 @@ defmodule Diplomat.ValueTest do
     } = Value.proto(nil)
   end
 
+  test "an atom value" do
+    assert %PbVal{
+      value_type: {:string_value, "atom"}
+    } = Value.proto(:atom)
+  end
+
   test "converting from a Value struct to the proto version" do
     assert %Diplomat.Proto.Value{
       value_type: {:string_value, "hello"}


### PR DESCRIPTION
Previously when trying to insert entities that included structs an error was raised:
```
** (FunctionClauseError) no function clause matching in Diplomat.Value.proto/1
```
To avoid problems when inserting this converts the structs into maps on `Entity.new`.

Atom values also caused problems when serializing. To fix this they are first converted to strings.