### PR TITLE
Improve `Entity` Typespecs

### DIFF
--- a/.dialyzer.ignore-warnings
+++ b/.dialyzer.ignore-warnings
@@ -1,0 +1,1 @@
+lib/exprotobuf

--- a/lib/diplomat/key.ex
+++ b/lib/diplomat/key.ex
@@ -14,7 +14,7 @@ defmodule Diplomat.Key do
   auto-assign an id by calling the API to allocate an id for the `Key`.
   """
   @type t :: %__MODULE__{
-    id:         String.t | nil,
+    id:         integer() | nil,
     name:       String.t | nil,
     kind:       String.t,
     parent:     Diplomat.Key.t | nil,
@@ -29,7 +29,7 @@ defmodule Diplomat.Key do
   def new(kind),
     do: %__MODULE__{kind: kind}
 
-  @spec new(String.t, String.t) :: t
+  @spec new(String.t, String.t | integer()) :: t
   @doc "Creates a new `Diplomat.Key` from a kind and id"
   def new(kind, id) when is_integer(id),
     do: %__MODULE__{kind: kind, id: id}
@@ -37,7 +37,7 @@ defmodule Diplomat.Key do
   def new(kind, name),
     do: %__MODULE__{kind: kind, name: name}
 
-  @spec new(String.t, String.t, t) :: t
+  @spec new(String.t, String.t | integer(), t) :: t
   @doc "Creates a new `Diplomat.Key` from a kind, an id or name, and a parent Entity"
   def new(kind, id_or_name, %__MODULE__{}=parent),
     do: %{new(kind, id_or_name) | parent: parent}

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,8 @@ defmodule Diplomat.Mixfile do
      elixir: "~> 1.3",
      description: "A library for interacting with Google's Cloud Datastore",
      package: package(),
-     deps: deps()]
+     deps: deps(),
+     dialyzer: [ignore_warnings: ".dialyzer.ignore-warnings"]]
   end
 
   def application do


### PR DESCRIPTION
This fixes several type errors in the the `Entity` module. Most of them are around possible nil values and cases in which an invalid `Key` could be constructed by the `Entity`. If I understand correctly a Key _must_ have a kind, while name and id are optional. In the past it was possible to create an entity with a nil kind and id which would build a Key without a kind.

This also ignores type errors within exprotobuf, at least for now.