### PR TITLE
Added support for "exclude_from_indexes" for Entity properties

### DIFF
--- a/lib/diplomat/value.ex
+++ b/lib/diplomat/value.ex
@@ -15,16 +15,8 @@ defmodule Diplomat.Value do
   defstruct value: nil, exclude_from_indexes: false
 
   @spec new(any) :: t
-  def new(val=%{__struct__: struct}) when struct in [Diplomat.Entity, Diplomat.Key, Diplomat.Value],
-    do: %__MODULE__{value: val}
-  def new(val=%{__struct__: _struct}),
-    do: new(Map.from_struct(val))
-  def new(val) when is_map(val),
-    do: %__MODULE__{value: Entity.new(val)}
-  def new(val) when is_list(val),
-    do: %__MODULE__{value: Enum.map(val, &new/1)}
   def new(val),
-    do: %__MODULE__{value: val}
+    do: new(val, false)
     
   @spec new(any, Boolean) :: t
   def new(val=%{__struct__: struct}, exclude_from_indexes) when struct in [Diplomat.Entity, Diplomat.Key, Diplomat.Value],

--- a/test/diplomat/exclude_from_index_test.exs
+++ b/test/diplomat/exclude_from_index_test.exs
@@ -1,0 +1,27 @@
+defmodule Diplomat.ExcludeFromIndexTest do
+    use ExUnit.Case
+    alias Diplomat.Proto.CommitResponse
+    alias Diplomat.Proto.CommitRequest
+    alias Diplomat.Proto.MutationResult
+    alias Diplomat.Proto.Mutation
+
+    alias Diplomat.{Key, Entity}
+
+    test "inserting an entity with exclude_from_indexes field" do
+        {:ok, project} = Goth.Config.get(:project_id)
+        {kind, name}   = {"TestBook", "my-book-unique-id"}
+        
+        entity = Entity.new(
+          %{
+            "name" => "My awesome book", 
+            "author" => "Phil Burrows",
+            "long_field" => String.duplicate("A very long field!", 1500)},
+          kind, 
+          name,
+          ["long_field"]
+        ) |> Entity.insert
+        
+        
+        
+    end
+end


### PR DESCRIPTION
Hi,

I've added support for setting the "exclude_from_indexes" flag on specific properties.
The API is similar to that of the python library.

Basically, when you create a new entity you can add an optional List argument whose entries are property names that will be excluded from indexing.
This is useful if you need to store very large values for specific properties, otherwise, there is a 1500 byte limit.

Not sure about the syntax as I am new to Erlang/Elixir
