### PR TITLE
Pagination

### DIFF
--- a/lib/diplomat/client.ex
+++ b/lib/diplomat/client.ex
@@ -1,5 +1,5 @@
 defmodule Diplomat.Client do
-  alias Diplomat.{Entity, Key}
+  alias Diplomat.{Entity, QueryResultBatch, Key}
 
   alias Diplomat.Proto.{
     AllocateIdsRequest,
@@ -93,6 +93,24 @@ defmodule Diplomat.Client do
         Enum.map(result.batch.entity_results, fn e ->
           Entity.from_proto(e.entity)
         end)
+
+      any ->
+        any
+    end
+  end
+
+  @spec run_query_with_pagination(RunQueryRequest.t()) :: QueryResultBatch.t() | error
+  @doc "Query for entities with pagination metadata"
+  def run_query_with_pagination(req) do
+    req
+    |> RunQueryRequest.encode()
+    |> call(:runQuery)
+    |> case do
+      {:ok, body} ->
+        body
+        |> RunQueryResponse.decode()
+        |> Map.get(:batch)
+        |> QueryResultBatch.from_proto()
 
       any ->
         any

--- a/lib/diplomat/cursor.ex
+++ b/lib/diplomat/cursor.ex
@@ -1,0 +1,17 @@
+defmodule Diplomat.Cursor do
+  @type t :: %__MODULE__{value: String.t()}
+
+  defstruct [:value]
+
+  @spec new(String.t(), Keyword.t()) :: t
+  def new(cursor_value, opts \\ [])
+  def new(cursor_value, encode: true), do: %__MODULE__{value: encode(cursor_value)}
+  def new(cursor_value, _opts), do: %__MODULE__{value: cursor_value}
+
+  @spec encode(String.t()) :: String.t()
+  def encode(cursor_value), do: Base.url_encode64(cursor_value)
+
+  @spec decode(t | String.t()) :: String.t()
+  def decode(%__MODULE__{} = cursor), do: decode(cursor.value)
+  def decode(value) when is_bitstring(value), do: Base.url_decode64!(value)
+end

--- a/lib/diplomat/query_result_batch.ex
+++ b/lib/diplomat/query_result_batch.ex
@@ -1,0 +1,23 @@
+defmodule Diplomat.QueryResultBatch do
+  alias Diplomat.{Cursor, Entity}
+  alias Diplomat.Proto.QueryResultBatch, as: PBQueryResultBatch
+
+  @type t :: %__MODULE__{entity_results: [Entity.t()], end_cursor: Cursor.t() | nil}
+
+  defstruct entity_results: [], end_cursor: nil
+
+  @spec from_proto(PBQueryResultBatch.t()) :: t
+  def from_proto(%PBQueryResultBatch{entity_results: entity_results, end_cursor: end_cursor}) do
+    %__MODULE__{
+      entity_results: entities_from_proto(entity_results),
+      end_cursor: maybe_create_cursor(end_cursor)
+    }
+  end
+
+  defp entities_from_proto(entity_results) do
+    Enum.map(entity_results, &Entity.from_proto(&1.entity))
+  end
+
+  defp maybe_create_cursor(nil), do: nil
+  defp maybe_create_cursor(end_cursor), do: Cursor.new(end_cursor, encode: true)
+end

--- a/test/diplomat/cursor_test.exs
+++ b/test/diplomat/cursor_test.exs
@@ -1,0 +1,35 @@
+defmodule Diplomat.CursorTest do
+  use ExUnit.Case
+
+  alias Diplomat.Cursor
+
+  @decoded_cursor_value <<255, 127, 254, 252>>
+
+  describe "Cursor.new/1" do
+    test "it create a new cursor" do
+      assert %Cursor{value: "_3_-_A=="} = Cursor.new("_3_-_A==")
+    end
+
+    test "it returns a new Cursor with an encoded value with 'encode' flag" do
+      assert %Cursor{value: "_3_-_A=="} = Cursor.new(@decoded_cursor_value, encode: true)
+    end
+  end
+
+  describe "Cursor.encode/1" do
+    test "encodes a cursor value into a base64 string" do
+      assert "_3_-_A==" == Cursor.encode(@decoded_cursor_value)
+    end
+  end
+
+  describe "Cursor.decode/1" do
+    test "decodes a Cursor struct" do
+      cursor = Cursor.new(@decoded_cursor_value, encode: true)
+
+      assert @decoded_cursor_value == Cursor.decode(cursor)
+    end
+
+    test "decodes a base64 encoded cursor value" do
+      assert @decoded_cursor_value == Cursor.decode("_3_-_A==")
+    end
+  end
+end

--- a/test/diplomat/query_result_batch_test.exs
+++ b/test/diplomat/query_result_batch_test.exs
@@ -1,0 +1,67 @@
+defmodule Diplomat.QueryResultBatchTest do
+  use ExUnit.Case
+  alias Diplomat.Proto.Entity, as: PbEntity
+  alias Diplomat.Proto.QueryResultBatch, as: PbQueryResultBatch
+  alias Diplomat.Proto.{EntityResult, Entity, PartitionId, Key, Value}
+  alias Diplomat.{Cursor, Entity, QueryResultBatch}
+
+  @query_result_batch %PbQueryResultBatch{
+    end_cursor:
+      <<10, 104, 10, 34, 10, 2, 105, 100, 18, 28, 26, 26, 111, 102, 102, 95, 48, 48, 48, 48, 57,
+        113, 54, 49, 98, 114, 49, 77, 66, 71, 56, 49, 54, 70, 65, 109, 107, 48, 18, 62, 106, 16,
+        100, 117, 102, 102, 101, 108, 45, 116, 109, 112, 45, 49, 49, 51, 51, 52, 114, 42, 11, 18,
+        10, 97, 105, 114, 95, 111, 102, 102, 101, 114, 115, 34, 26, 111, 102, 102, 95, 48, 48, 48,
+        48, 57, 113, 54, 49, 98, 114, 49, 77, 66, 71, 56, 49, 54, 70, 65, 109, 107, 48, 12, 24, 0,
+        32, 0>>,
+    entity_result_type: :PROJECTION,
+    entity_results: [
+      %EntityResult{
+        cursor:
+          <<10, 104, 10, 34, 10, 2, 105, 100, 18, 28, 26, 26, 111, 102, 102, 95, 48, 48, 48, 48,
+            57, 113, 54, 49, 98, 114, 49, 77, 66, 71, 56, 49, 54, 70, 65, 109, 107, 48, 18, 62,
+            106, 16, 100, 117, 102, 102, 101, 108, 45, 116, 109, 112, 45, 49, 49, 51, 51, 52, 114,
+            42, 11, 18, 10, 97, 105, 114, 95, 111, 102, 102, 101, 114, 115, 34, 26, 111, 102, 102,
+            95, 48, 48, 48, 48, 57, 113, 54, 49, 98, 114, 49, 77, 66, 71, 56, 49, 54, 70, 65, 109,
+            107, 48, 12, 24, 0, 32, 0>>,
+        entity: %PbEntity{
+          key: %Key{
+            partition_id: %PartitionId{
+              namespace_id: nil,
+              project_id: "diplomat"
+            },
+            path: [
+              %Key.PathElement{
+                id_type: {:name, "123_foo"},
+                kind: "foo_table"
+              }
+            ]
+          },
+          properties: [
+            {"id",
+             %Value{
+               exclude_from_indexes: nil,
+               meaning: 18,
+               value_type: {:string_value, "123_foo"}
+             }}
+          ]
+        }
+      }
+    ],
+    more_results: :MORE_RESULTS_AFTER_LIMIT,
+    skipped_cursor: nil,
+    skipped_results: nil
+  }
+
+  describe "QueryResultBatch.from_proto/1" do
+    test "given a list of entity results and an end_cursor" do
+      pb_query_result_batch_end_cursor = @query_result_batch.end_cursor
+
+      assert %QueryResultBatch{
+               entity_results: [%Entity{}],
+               end_cursor: %Cursor{value: value}
+             } = QueryResultBatch.from_proto(@query_result_batch)
+
+      assert pb_query_result_batch_end_cursor == Cursor.decode(value)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds pagination functionality to the `Query` module (by leveraging the cursors exposed in the `QueryResultBatch`). With this we will be able to use Diplomat in order to iterate through pages of DataStore entities.

I've made efforts to keep the changes backwards compatible with previous versions 🤞

Example:

```elixir
cursor = Cursor.new("BASE64_ENCODED")

"SELECT * FROM table OFFSET @1" 
|> Diplomat.Query.new([cursor])
|> Diplomat.Query.execute_with_pagination()
```