### PR TITLE
Add ability to pull/push under different goth service accounts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ config/*credentials.json
 .#*
 /doc/
 .elixir_ls/
+.idea/
+*.iml

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Require Diplomat and use the with_account option to set current (and only curren
 The account name will be the client_email value from the additional Goth configuration you added by default.
 
 ```elixir
+require Diplomat
 # copy data from prod to stage environment
 
 # 1. Fetch data from production account

--- a/README.md
+++ b/README.md
@@ -41,3 +41,37 @@ Diplomat.Query.new(
   %{name: "20,000 Leagues Under The Sea"}
 ) |> Diplomat.Query.execute
 ```
+
+
+#### Use multiple accounts with Diplomat
+Configure Goth with additional accounts.
+```elixir
+{:ok, alternative_account} = Jason.decode(File.read!("priv/goth/alternative-account.json"))
+Goth.Config.add_config(alternative_account)
+```
+
+Require Diplomat and use the with_account option to set current (and only current) process to use alternative process within block. 
+
+The account name will be the client_email value from the additional Goth configuration you added by default.
+
+```elixir
+# copy data from prod to stage environment
+
+# 1. Fetch data from production account
+prod_data = Diplomat.with_account(alternative_account["client_email"]) do
+  Diplomat.Query.new(
+    "select * from `Book` where name = @name",
+    %{name: "20,000 Leagues Under The Sea"}
+  ) |> Diplomat.Query.execute
+end
+
+# 2. Write to stage/dev account (default environment)
+Enum.map(prod_data, fn(entity) -> 
+  Diplomat.Entity.upsert(entity)
+end)
+```
+
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ require Diplomat
 # copy data from prod to stage environment
 
 # 1. Fetch data from production account
-prod_data = Diplomat.with_account(alternative_account["client_email"]) do
+prod_entities = Diplomat.with_account(alternative_account["client_email"]) do
   Diplomat.Query.new(
     "select * from `Book` where name = @name",
     %{name: "20,000 Leagues Under The Sea"}
@@ -67,9 +67,11 @@ prod_data = Diplomat.with_account(alternative_account["client_email"]) do
 end
 
 # 2. Write to stage/dev account (default environment)
-Enum.map(prod_data, fn(entity) -> 
-  Diplomat.Entity.upsert(entity)
-end)
+target_project = Diplomat.Client.project()
+stage_entities = Enum.map(prod_entities, fn(entity) ->
+      put_in(entity, [Access.key(:key), Access.key(:project_id)], target_project)
+    end)
+Diplomat.Entity.upsert(stage_entities)
 ```
 
 

--- a/lib/diplomat.ex
+++ b/lib/diplomat.ex
@@ -9,4 +9,21 @@ defmodule Diplomat do
   defmodule Proto do
     use Protobuf, from: Path.expand("datastore_v1beta3.proto", __DIR__), doc: false
   end
+
+  defmacro with_account(account, [do: block]) do
+    account = Macro.expand(account, __ENV__)
+    quote do
+      Process.put(:diplomat_account_queue, [unquote(account)] ++ Process.get(:diplomat_account_queue, []))
+      Process.put(:diplomat_account, unquote(account))
+      diplomat__response = (unquote(block))
+      diplomat__account_queue = case Process.get(:diplomat_account_queue, []) do
+                                  [_|t] -> t
+                                  _ -> []
+                                end
+      Process.put(:diplomat_account_queue, diplomat__account_queue)
+      Process.put(:diplomat_account, List.first(diplomat__account_queue))
+      diplomat__response
+    end
+  end
+  
 end

--- a/lib/diplomat/client.ex
+++ b/lib/diplomat/client.ex
@@ -181,8 +181,8 @@ defmodule Diplomat.Client do
 
   defp auth_header do
     {:ok, token} = case diplomat_account() do
-                     nil -> {:ok, token} = token_module().for_scope(api_scope())
-                     account -> {:ok, token} = token_module().for_scope({account, api_scope()})
+                     nil -> token_module().for_scope(api_scope())
+                     account -> token_module().for_scope({account, api_scope()})
                    end
     {"Authorization", "#{token.type} #{token.token}"}
   end

--- a/lib/diplomat/key.ex
+++ b/lib/diplomat/key.ex
@@ -92,7 +92,7 @@ defmodule Diplomat.Key do
           nil
 
         _ ->
-          {:ok, global_project_id} = Goth.Config.get(:project_id)
+          global_project_id = Diplomat.Client.project()
 
           PbPartition.new(
             project_id: key.project_id || global_project_id,

--- a/lib/diplomat/query.ex
+++ b/lib/diplomat/query.ex
@@ -43,7 +43,7 @@ defmodule Diplomat.Query do
 
   @spec execute(t, String.t() | nil) :: [Entity.t()] | Client.error()
   def execute(%__MODULE__{} = q, namespace \\ nil) do
-    {:ok, project} = Goth.Config.get(:project_id)
+    project = Diplomat.Client.project()
 
     RunQueryRequest.new(
       query_type: {:gql_query, q |> Query.proto()},
@@ -54,7 +54,7 @@ defmodule Diplomat.Query do
 
   @spec execute_with_pagination(t, String.t() | nil) :: [QueryResultBatch.t()] | Client.error()
   def execute_with_pagination(%__MODULE__{} = q, namespace \\ nil) do
-    {:ok, project} = Goth.Config.get(:project_id)
+    project = Diplomat.Client.project()
 
     RunQueryRequest.new(
       query_type: {:gql_query, q |> Query.proto()},

--- a/test/diplomat/account_override_test.exs
+++ b/test/diplomat/account_override_test.exs
@@ -1,0 +1,27 @@
+defmodule Diplomat.AccountOverrideTest do
+  use ExUnit.Case
+  require Diplomat
+  
+  test "Verify account overrides are applied correctly" do
+    assert Diplomat.Client.diplomat_account() == nil
+    r = Diplomat.with_account(:alternative_account_email) do
+      assert Diplomat.Client.diplomat_account() == :alternative_account_email
+      a = Diplomat.with_account(:alternative_account2_email) do
+        assert Diplomat.Client.diplomat_account() == :alternative_account2_email
+        :alpha
+      end
+      assert a == :alpha
+      assert Diplomat.Client.diplomat_account() == :alternative_account_email
+      b = Diplomat.with_account(:alternative_account3_email) do
+        assert Diplomat.Client.diplomat_account() == :alternative_account3_email
+        :beta
+      end
+      assert b == :beta
+      assert Diplomat.Client.diplomat_account() == :alternative_account_email
+      :omega
+    end
+    assert Diplomat.Client.diplomat_account() == nil
+    assert r == :omega
+  end
+  
+end


### PR DESCRIPTION
I have a requirement on this functionality for synchronizing my stage/dev environments with the production data sets.  It may also be useful if you have a restricted auth account by default but sometimes need to use an elevated account to make certain requests. 

The feature works by pushing a value to the current process dictionary and referencing that value when preparing request tokens or determining the current project_id. 

If the functionality is not referenced I've constructed the Goth calls to use the previous format (rather than just setting account to :default and using the {account, field} version of methods.) to avoid impacting any upstream users if they, for example,  have overridden the module used by defp token_module() and their implementation does not support the for_scope({account, scope}) format. 

The Readme has been updated with an example of how to use this feature: 

```elixir
require Diplomat
# copy data from prod to stage environment
# 1. Fetch data from production account
prod_data = Diplomat.with_account(alternative_account["client_email"]) do
  Diplomat.Query.new(
    "select * from `Book` where name = @name",
    %{name: "20,000 Leagues Under The Sea"}
  ) |> Diplomat.Query.execute
end
# 2. Write to stage/dev account (default environment)
Enum.map(prod_data, fn(entity) -> 
  Diplomat.Entity.upsert(entity)
end)
```

